### PR TITLE
[Task #29] Xử lý phản hồi va chạm tách trục

### DIFF
--- a/engine/physics/CCollision.cpp
+++ b/engine/physics/CCollision.cpp
@@ -7,86 +7,69 @@ bool CCollision::CheckAABB(const Box &a, const Box &b) {
     return !(a.r <= b.l || a.l >= b.r || a.b <= b.t || a.t >= b.b);
 }
 
-void CCollision::ResolveCollision(CGameObject* obj, const std::vector<CGameObject*>& coObjects) {
+void CCollision::ResolveCollision(CGameObject* obj, float dt, const std::vector<CGameObject*>& coObjects) {
     if (!obj) return;
 
-    float l1,t1,r1,b1;
-    obj->GetBoundingBox(l1,t1,r1,b1);
+    // --- STEP 1: X-Axis Movement and Resolution ---
+    obj->x += obj->vx * dt;
 
-    struct CollisionEvent {
-        CGameObject* other;
-        float overlapArea;
-    };
-    std::vector<CollisionEvent> events;
+    float l1, t1, r1, b1;
+    obj->GetBoundingBox(l1, t1, r1, b1);
+    Box A = ToBox(l1, t1, r1, b1);
+    float objWidth = r1 - l1;
 
     for (auto other : coObjects) {
         if (!other || other == obj) continue;
-        float l2,t2,r2,b2;
-        other->GetBoundingBox(l2,t2,r2,b2);
+        float l2, t2, r2, b2;
+        other->GetBoundingBox(l2, t2, r2, b2);
+        Box B = ToBox(l2, t2, r2, b2);
 
-        Box A = ToBox(l1,t1,r1,b1);
-        Box B = ToBox(l2,t2,r2,b2);
-
-        if (CheckAABB(A,B)) {
-            float overlapX = (std::min)(A.r, B.r) - (std::max)(A.l, B.l);
-            float overlapY = (std::min)(A.b, B.b) - (std::max)(A.t, B.t);
-            events.push_back({other, overlapX * overlapY});
+        if (CheckAABB(A, B)) {
+            // Resolve X axis
+            if (obj->vx > 0) {
+                // Moving right, hit left side of 'other'
+                obj->x = B.l - objWidth;
+            } else if (obj->vx < 0) {
+                // Moving left, hit right side of 'other'
+                obj->x = B.r;
+            }
+            obj->vx = 0;
+            
+            // Re-update bounding box A for subsequent overlap checks in X
+            obj->GetBoundingBox(l1, t1, r1, b1);
+            A = ToBox(l1, t1, r1, b1);
         }
     }
 
-    // Sort by largest overlap area to fix ghost collisions completely
-    std::sort(events.begin(), events.end(), [](const CollisionEvent& a, const CollisionEvent& b) {
-        return a.overlapArea > b.overlapArea;
-    });
+    // --- STEP 2: Y-Axis Movement and Resolution ---
+    obj->y += obj->vy * dt;
 
-    for (auto ev : events) {
-        auto other = ev.other;
+    obj->GetBoundingBox(l1, t1, r1, b1);
+    A = ToBox(l1, t1, r1, b1);
+    float objHeight = b1 - t1;
 
-        // Re-get bounding box because obj might have moved
-        obj->GetBoundingBox(l1,t1,r1,b1);
-        float l2,t2,r2,b2;
-        other->GetBoundingBox(l2,t2,r2,b2);
+    for (auto other : coObjects) {
+        if (!other || other == obj) continue;
+        float l2, t2, r2, b2;
+        other->GetBoundingBox(l2, t2, r2, b2);
+        Box B = ToBox(l2, t2, r2, b2);
 
-        Box A = ToBox(l1,t1,r1,b1);
-        Box B = ToBox(l2,t2,r2,b2);
-
-        if (!CheckAABB(A,B)) continue;
-
-        float overlapX = (std::min)(A.r, B.r) - (std::max)(A.l, B.l);
-        float overlapY = (std::min)(A.b, B.b) - (std::max)(A.t, B.t);
-
-        float center1_x = (A.l + A.r) * 0.5f;
-        float center2_x = (B.l + B.r) * 0.5f;
-        float center1_y = (A.t + A.b) * 0.5f;
-        float center2_y = (B.t + B.b) * 0.5f;
-
-        // Choose minimal axis to resolve (shortest penetration distance)
-        bool preferY = (overlapY <= overlapX);
-
-        if (!preferY) {
-            // resolve X axis precisely away from center
-            if (center1_x < center2_x) {
-                obj->x -= overlapX;
-            } else {
-                obj->x += overlapX;
-            }
-            obj->vx = 0;
-        } else {
-            // resolve Y axis precisely away from center
-            float objHeight = A.b - A.t;
-            if (center1_y > center2_y) {
-                // obj center is higher -> hits from above -> land on top
+        if (CheckAABB(A, B)) {
+            // Resolve Y axis
+            if (obj->vy < 0) {
+                // Falling down, hit top side of 'other'
                 obj->y = B.b;
                 obj->vy = 0;
                 if (auto m = dynamic_cast<CMario*>(obj)) m->SetOnGround(true);
-            } else {
-                // obj center is lower -> hits from below -> bonk head / push down
+            } else if (obj->vy > 0) {
+                // Jumping up, hit bottom side of 'other' (Ceiling)
                 obj->y = B.t - objHeight;
                 obj->vy = 0;
             }
+            
+            // Re-update bounding box A for subsequent overlap checks in Y
+            obj->GetBoundingBox(l1, t1, r1, b1);
+            A = ToBox(l1, t1, r1, b1);
         }
-
-        // update bounding box for subsequent checks (if moved)
-        obj->GetBoundingBox(l1,t1,r1,b1);
     }
 }

--- a/engine/physics/CCollision.h
+++ b/engine/physics/CCollision.h
@@ -11,5 +11,5 @@ public:
     static bool CheckAABB(const Box &a, const Box &b);
 
     // Resolve collisions between `obj` and list of coObjects (static blocks etc.)
-    static void ResolveCollision(CGameObject* obj, const std::vector<CGameObject*>& coObjects);
+    static void ResolveCollision(CGameObject* obj, float dt, const std::vector<CGameObject*>& coObjects);
 };

--- a/game/entities/player/CMario.cpp
+++ b/game/entities/player/CMario.cpp
@@ -23,9 +23,6 @@ void CMario::Update(float dt) {
     SetOnGround(false);
 
     ApplyPhysics(dt);
-
-    x += vx * dt;
-    y += vy * dt;
 }
 
 void CMario::HandleInput(const InputState& input, float dt) {

--- a/game/scenes/play/CPlayScene.cpp
+++ b/game/scenes/play/CPlayScene.cpp
@@ -38,6 +38,11 @@ void CPlayScene::Load() {
             blocks.push_back(new CBrick((flatStartX + i) * 16.0f, 50.0f + h * 16.0f));
         }
     }
+
+    // 5. Hàng gạch làm trần nhà để test đụng đầu
+    for (int i = 0; i < 5; i++) {
+        blocks.push_back(new CBrick((flatStartX + i) * 16.0f, 50.0f + 9 * 16.0f));
+    }
     DebugOut(L"[INFO] CPlayScene::Load complete. Blocks: %d\n", blocks.size());
 }
 

--- a/game/scenes/play/CPlayScene.cpp
+++ b/game/scenes/play/CPlayScene.cpp
@@ -48,7 +48,7 @@ void CPlayScene::Update(float dt) {
     std::vector<CGameObject*> coObjects;
     coObjects.reserve(blocks.size());
     for (auto b : blocks) coObjects.push_back(b);
-    CCollision::ResolveCollision(mario, coObjects);
+    CCollision::ResolveCollision(mario, dt, coObjects);
     CCamera::GetInstance()->Update(mario->x, mario->y, (DWORD)dt);
 }
 


### PR DESCRIPTION
## Mô tả thay đổi
- Áp dụng phương pháp kiểm tra va chạm **Tách trục (X và Y độc lập)** vào hàm `CCollision::ResolveCollision`.
- Gỡ bỏ việc cộng tọa độ trực tiếp trong `CMario::Update`, thay vào đó nhường quyền kiểm soát di chuyển (tích phân `vx * dt`, `vy * dt`) cho Engine Vật lý `CCollision` xử lý từng bước.
- **Trục X (Ngang):** Di chuyển X, kiểm tra hộp va chạm. Mọi giao thoa đều được đẩy văng ra sát mép tường và triệt tiêu `vx = 0`.
- **Trục Y (Dọc):** Di chuyển Y, kiểm tra hộp va chạm. Xử lý triệt để rơi chạm đất (`vy = 0`, `onGround = true`) và nhảy đụng trần nhà (bị dội ngược xuống lề dưới gạch đứng, `vy = 0`).
- Dựng thêm một dãy gạch "trần nhà" ở map `CPlayScene` để phục vụ test case phản hồi chạm đỉnh đầu.
- **Hiệu quả:** Xóa bỏ hoàn toàn exception dính tường, kẹt cứng ở gờ gạch, vấp khe nối hay lún người xuống đất.

## Issue liên quan
- Closes #29

## Kiểm thử (Testing Checklist)
- [ ] Rơi tự do đỗ khít trên nền đất cứng, set đúng state `ON_GROUND`.
- [ ] Trôi ngang đập vào cột đứng ở bên trái map bị cản lại (Vận tốc X về 0).
- [ ] Vừa bấm nhảy chéo vừa đè phím di chuyển lấn vào tường thẳng đứng: KHÔNG BỊ TRƯỢT DÍNH TƯỜNG HAY LƠ LỬNG.
- [ ] Nhảy đập đầu vào hàng gạch trần nhà (Ceiling) mới thêm ở cuối: Mario bị đánh bật xuống chạm đất ngay lập tức.