### PR TITLE
# [Task #50, #51, #54] Smart Enemy Patrol, Koopa Shell Mechanics & HUD Integration

### DIFF
--- a/engine/core/Game.cpp
+++ b/engine/core/Game.cpp
@@ -103,9 +103,23 @@ void CGame::Init(HWND hWnd, HINSTANCE hInstance)
 
 	D3DX10CreateSprite(pD3DDevice, 0, &spriteObject);
 
-	SetPointSamplerState();
+    D3DX10_FONT_DESCW fd;
+    ZeroMemory(&fd, sizeof(fd));
+    fd.Height = 16;
+    fd.Width = 0;
+    fd.Weight = FW_BOLD;
+    fd.MipLevels = 1;
+    fd.Italic = false;
+    fd.CharSet = DEFAULT_CHARSET;
+    fd.OutputPrecision = OUT_DEFAULT_PRECIS;
+    fd.Quality = ANTIALIASED_QUALITY;
+    fd.PitchAndFamily = DEFAULT_PITCH | FF_DONTCARE;
+    wcscpy_s(fd.FaceName, L"Arial");
+    D3DX10CreateFontIndirectW(pD3DDevice, &fd, &pFont);
 
-	DebugOut(L"[INFO] InitDirectX has been successful\n");
+    SetPointSamplerState();
+
+    DebugOut(L"[INFO] InitDirectX has been successful\n");
 }
 
 void CGame::SetPointSamplerState()
@@ -127,7 +141,11 @@ void CGame::SetPointSamplerState()
 
 	pD3DDevice->CreateSamplerState(&desc, &pPointSamplerState);
 }
-
+void CGame::DrawTextRaw(LPCWSTR text, RECT rect, D3DXCOLOR color)
+{
+    if (pFont == NULL) return;
+    pFont->DrawTextW(NULL, text, -1, &rect, DT_LEFT | DT_TOP | DT_NOCLIP, color);
+}
 void CGame::Draw(float x, float y, LPTEXTURE tex, RECT* rect, float alpha, int sprite_width, int sprite_height)
 {
 	if (tex == NULL) return;
@@ -211,8 +229,7 @@ CGame* CGame::GetInstance()
 }
 
 CGame::~CGame()
-{
-	if (pPointSamplerState != NULL) pPointSamplerState->Release();
+{    if (pFont != NULL) pFont->Release();	if (pPointSamplerState != NULL) pPointSamplerState->Release();
 	if (spriteObject != NULL) spriteObject->Release();
 	if (pBlendStateAlpha != NULL) pBlendStateAlpha->Release();
 	if (pRenderTargetView != NULL) pRenderTargetView->Release();

--- a/engine/core/Game.h
+++ b/engine/core/Game.h
@@ -28,12 +28,13 @@ class CGame
 	HINSTANCE hInstance;
 
 	ID3D10SamplerState* pPointSamplerState;
+        ID3DX10Font* pFont = NULL;
 
 public:
-	void Init(HWND hWnd, HINSTANCE hInstance);
+        void Init(HWND hWnd, HINSTANCE hInstance);
 
-	void Draw(float x, float y, LPTEXTURE tex, RECT* rect = NULL, float alpha = 1.0f, int sprite_width = 0, int sprite_height = 0);
-
+        void Draw(float x, float y, LPTEXTURE tex, RECT* rect = NULL, float alpha = 1.0f, int sprite_width = 0, int sprite_height = 0);
+        void DrawTextRaw(LPCWSTR text, RECT rect, D3DXCOLOR color);
 	void Draw(float x, float y, LPTEXTURE tex, int l, int t, int r, int b, float alpha = 1.0f, int sprite_width = 0, int sprite_height = 0)
 	{
 		RECT rect;

--- a/engine/core/GameLoop.cpp
+++ b/engine/core/GameLoop.cpp
@@ -85,6 +85,21 @@ void Render()
     RenderGame(g);
 
     spriteHandler->End();
+
+    // Render HUD
+    if (scene != nullptr) {
+        RECT rect;
+        rect.left = 10;
+        rect.top = 10;
+        rect.right = g->GetBackBufferWidth();
+        rect.bottom = g->GetBackBufferHeight();
+
+        wchar_t buffer[256];
+        swprintf_s(buffer, L"MARIO\n%06d\n\nCOINS\n%02d\n\nWORLD\n1-1\n\nTIME\n%03d", 
+                    scene->GetScore(), scene->GetCoins(), scene->GetTime());
+        g->DrawTextRaw(buffer, rect, D3DXCOLOR(1.0f, 1.0f, 1.0f, 1.0f));
+    }
+
     pSwapChain->Present(0, 0);
 }
 

--- a/engine/physics/CCollision.cpp
+++ b/engine/physics/CCollision.cpp
@@ -19,7 +19,18 @@ void CCollision::ResolveCollision(CGameObject* obj, float dt, const std::vector<
     float objWidth = right1 - left1;
 
     for (auto other : coObjects) {
-        if (!other || other == obj) continue;
+        if (!other || other == obj || !obj->IsBlocking(other) || !other->IsBlocking(obj)) {
+            // Still check overlap for trigger events
+            if (other && other != obj) {
+                float l2, b2, r2, t2;
+                other->GetBoundingBox(l2, b2, r2, t2);
+                if (CheckAABB(A, ToBox(l2, b2, r2, t2))) {
+                    obj->OnCollisionX(other, 0);
+                    other->OnCollisionX(obj, 0);
+                }
+            }
+            continue;
+        }
         float left2, bottom2, right2, top2;
         other->GetBoundingBox(left2, bottom2, right2, top2);
         Box B = ToBox(left2, bottom2, right2, top2);
@@ -29,9 +40,13 @@ void CCollision::ResolveCollision(CGameObject* obj, float dt, const std::vector<
             if (obj->vx > 0) {
                 // Moving right, hit left side of 'other'
                 obj->x = B.left - objWidth;
+                obj->OnCollisionX(other, 1);
+                other->OnCollisionX(obj, -1);
             } else if (obj->vx < 0) {
                 // Moving left, hit right side of 'other'
                 obj->x = B.right;
+                obj->OnCollisionX(other, -1);
+                other->OnCollisionX(obj, 1);
             }
             obj->vx = 0;
             
@@ -49,7 +64,17 @@ void CCollision::ResolveCollision(CGameObject* obj, float dt, const std::vector<
     float objHeight = top1 - bottom1;
 
     for (auto other : coObjects) {
-        if (!other || other == obj) continue;
+        if (!other || other == obj || !obj->IsBlocking(other) || !other->IsBlocking(obj)) {
+            if (other && other != obj) {
+                float l2, b2, r2, t2;
+                other->GetBoundingBox(l2, b2, r2, t2);
+                if (CheckAABB(A, ToBox(l2, b2, r2, t2))) {
+                    obj->OnCollisionY(other, 0);
+                    other->OnCollisionY(obj, 0);
+                }
+            }
+            continue;
+        }
         float left2, bottom2, right2, top2;
         other->GetBoundingBox(left2, bottom2, right2, top2);
         Box B = ToBox(left2, bottom2, right2, top2);
@@ -60,12 +85,16 @@ void CCollision::ResolveCollision(CGameObject* obj, float dt, const std::vector<
                 // Falling down, hit top side of 'other'
                 obj->y = B.top;
                 obj->vy = 0;
+                obj->OnCollisionY(other, -1);
+                other->OnCollisionY(obj, 1);
                 if (auto m = dynamic_cast<CMario*>(obj)) m->SetOnGround(true);
             } else if (obj->vy > 0) {
                 // Jumping up, hit bottom side of 'other' (Ceiling) // <--- THIS is where Mario hits a block from below
                 obj->y = B.bottom - objHeight;
                 obj->vy = 0;
                 other->OnHitFromBelow(obj);
+                obj->OnCollisionY(other, 1);
+                other->OnCollisionY(obj, -1);
             }
             
             // Re-update bounding box A for subsequent overlap checks in Y

--- a/game/entities/CGameObject.h
+++ b/game/entities/CGameObject.h
@@ -8,7 +8,11 @@ public:
     int nx;        // Hướng quay mặt (1: phải, -1: trái)
 
     CGameObject() : x(100), y(100), vx(0), vy(0), ax(0), ay(0), nx(1) {}
+    virtual ~CGameObject() {}
+    virtual bool IsBlocking(CGameObject* other) { return true; }
     virtual void OnHitFromBelow(CGameObject* hitter) {}
+    virtual void OnCollisionX(CGameObject* other, float nx) {}
+    virtual void OnCollisionY(CGameObject* other, float ny) {}
     virtual void Update(float dt) = 0;
     virtual void Render() = 0;
     virtual void GetBoundingBox(float &left, float &bottom, float &right, float &top) = 0;

--- a/game/entities/enemies/CGoomba.cpp
+++ b/game/entities/enemies/CGoomba.cpp
@@ -35,10 +35,13 @@ bool CGoomba::IsBlocking(CGameObject* other) {
     return true; // Optionally don't block running shell
 }
 
+#include "../../scenes/play/CPlayScene.h"
+
 void CGoomba::OnCollisionY(CGameObject* other, float ny) {
     if (ny > 0) { // Hit from top
         if (dynamic_cast<CMario*>(other)) {
             SetState(GOOMBA_STATE_DIE);
+            if (scene) scene->AddScore(100);
             other->vy = 0.2f; // bounce mario
         }
     }

--- a/game/entities/enemies/CGoomba.cpp
+++ b/game/entities/enemies/CGoomba.cpp
@@ -1,5 +1,6 @@
 #include "CGoomba.h"
 #include "../../../engine/Graphics/Animations.h"
+#include "../../entities/player/CMario.h"
 
 CGoomba::CGoomba(float x, float y, float patrolLeft, float patrolRight) : CGameObject() {
     this->x = x;
@@ -27,6 +28,20 @@ void CGoomba::GetBoundingBox(float& left, float& bottom, float& right, float& to
         top = y + GOOMBA_BBOX_HEIGHT_DIE;
     else
         top = y + GOOMBA_BBOX_HEIGHT;
+}
+
+bool CGoomba::IsBlocking(CGameObject* other) {
+    if (state == GOOMBA_STATE_DIE) return false;
+    return true; // Optionally don't block running shell
+}
+
+void CGoomba::OnCollisionY(CGameObject* other, float ny) {
+    if (ny > 0) { // Hit from top
+        if (dynamic_cast<CMario*>(other)) {
+            SetState(GOOMBA_STATE_DIE);
+            other->vy = 0.2f; // bounce mario
+        }
+    }
 }
 
 void CGoomba::SetState(int s) {

--- a/game/entities/enemies/CGoomba.h
+++ b/game/entities/enemies/CGoomba.h
@@ -20,4 +20,7 @@ public:
     void Render() override;
     void GetBoundingBox(float &left, float &bottom, float &right, float &top) override;
     void SetState(int s);
+
+    bool IsBlocking(CGameObject* other) override;
+    void OnCollisionY(CGameObject* other, float ny) override;
 };

--- a/game/entities/enemies/CKoopa.cpp
+++ b/game/entities/enemies/CKoopa.cpp
@@ -47,12 +47,16 @@ void CKoopa::GetBoundingBox(float& left, float& bottom, float& right, float& top
     }
 }
 
+#include "../../scenes/play/CPlayScene.h"
+
 void CKoopa::OnCollisionX(CGameObject* other, float nx) {
     if (state == KOOPA_STATE_SHELL_RUNNING) {
         if (auto goomba = dynamic_cast<CGoomba*>(other)) {
             goomba->SetState(GOOMBA_STATE_DIE);
+            if (scene) scene->AddScore(100);
         } else if (auto koopa = dynamic_cast<CKoopa*>(other)) {
             koopa->SetState(KOOPA_STATE_SHELL); // or whatever
+            if (scene) scene->AddScore(100);
         } else if (auto mario = dynamic_cast<CMario*>(other)) {
             // mario takes hit if it's running? Actually Mario handles his own hits.
         }
@@ -69,6 +73,7 @@ void CKoopa::OnCollisionY(CGameObject* other, float ny) {
         if (auto mario = dynamic_cast<CMario*>(other)) {
             if (state == KOOPA_STATE_WALKING || state == KOOPA_STATE_SHELL_RUNNING) {
                 SetState(KOOPA_STATE_SHELL);
+                if (scene) scene->AddScore(100);
                 mario->vy = 0.2f; // Mario bounces up
             } else if (state == KOOPA_STATE_SHELL) {
                 this->nx = (mario->x < this->x) ? 1 : -1;

--- a/game/entities/enemies/CKoopa.cpp
+++ b/game/entities/enemies/CKoopa.cpp
@@ -1,12 +1,26 @@
 #include "CKoopa.h"
 #include "../../../engine/Graphics/Animations.h"
+#include "../../entities/player/CMario.h"
+#include "CGoomba.h"
 
 CKoopa::CKoopa(float x, float y, std::string type, float patrolLeft, float patrolRight) 
     : CGameObject(), type(type) {
     this->x = x;
     this->y = y;
-    this->vx = -0.03f;
+    SetState(KOOPA_STATE_WALKING);
     this->nx = -1;
+}
+
+void CKoopa::SetState(int s) {
+    state = s;
+    if (state == KOOPA_STATE_WALKING) {
+        vx = -0.03f;
+    } else if (state == KOOPA_STATE_SHELL) {
+        vx = 0;
+        vy = 0;
+    } else if (state == KOOPA_STATE_SHELL_RUNNING) {
+        vx = 0.15f * nx;
+    }
 }
 
 void CKoopa::Update(float dt) {
@@ -16,6 +30,9 @@ void CKoopa::Update(float dt) {
 
 void CKoopa::Render() {
     std::string ani = "ANI_KOOPA_WALK";
+    if (state == KOOPA_STATE_SHELL || state == KOOPA_STATE_SHELL_RUNNING) {
+        ani = "ANI_KOOPA_SHELL"; // Assuming you have this animation
+    }
     CAnimations::GetInstance()->Render(ani, x, y, nx);
 }
 
@@ -23,5 +40,54 @@ void CKoopa::GetBoundingBox(float& left, float& bottom, float& right, float& top
     left = x;
     bottom = y;
     right = x + 16.0f;
-    top = y + 16.0f;
+    if (state == KOOPA_STATE_WALKING) {
+        top = y + 24.0f; // Walk bbox
+    } else {
+        top = y + 16.0f; // Shell bbox
+    }
+}
+
+void CKoopa::OnCollisionX(CGameObject* other, float nx) {
+    if (state == KOOPA_STATE_SHELL_RUNNING) {
+        if (auto goomba = dynamic_cast<CGoomba*>(other)) {
+            goomba->SetState(GOOMBA_STATE_DIE);
+        } else if (auto koopa = dynamic_cast<CKoopa*>(other)) {
+            koopa->SetState(KOOPA_STATE_SHELL); // or whatever
+        } else if (auto mario = dynamic_cast<CMario*>(other)) {
+            // mario takes hit if it's running? Actually Mario handles his own hits.
+        }
+    } else if (state == KOOPA_STATE_SHELL) {
+        if (auto mario = dynamic_cast<CMario*>(other)) {
+            this->nx = (mario->x < this->x) ? 1 : -1;
+            SetState(KOOPA_STATE_SHELL_RUNNING);
+        }
+    }
+}
+
+void CKoopa::OnCollisionY(CGameObject* other, float ny) {
+    if (ny > 0) { // Hit from top (other landed on this)
+        if (auto mario = dynamic_cast<CMario*>(other)) {
+            if (state == KOOPA_STATE_WALKING || state == KOOPA_STATE_SHELL_RUNNING) {
+                SetState(KOOPA_STATE_SHELL);
+                mario->vy = 0.2f; // Mario bounces up
+            } else if (state == KOOPA_STATE_SHELL) {
+                this->nx = (mario->x < this->x) ? 1 : -1;
+                SetState(KOOPA_STATE_SHELL_RUNNING);
+                mario->vy = 0.2f;
+            }
+        }
+    }
+}
+
+bool CKoopa::IsBlocking(CGameObject* other) {
+    if (auto mario = dynamic_cast<CMario*>(other)) {
+        // If Koopa is Shell running, or Mario runs into Shell, does it physically block?
+        // Usually Mario takes damage or kicks it, but we can let it be non-blocking physically
+        // so Mario overlaps slightly, and trigger event pushes/damages Mario?
+        // Or keep it blocking. Let's just return true except maybe if Koopa is running and other is enemy
+    }
+    if (state == KOOPA_STATE_SHELL_RUNNING && dynamic_cast<CGoomba*>(other)) {
+        return false; // don't block physics when plowing
+    }
+    return true;
 }

--- a/game/entities/enemies/CKoopa.h
+++ b/game/entities/enemies/CKoopa.h
@@ -2,11 +2,22 @@
 #include "../CGameObject.h"
 #include <string>
 
+#define KOOPA_STATE_WALKING 100
+#define KOOPA_STATE_SHELL 200
+#define KOOPA_STATE_SHELL_RUNNING 300
+
 class CKoopa : public CGameObject {
     std::string type;
+    int state;
 public:
     CKoopa(float x, float y, std::string type = "green_walking", float patrolLeft = 0, float patrolRight = 0);
     void Update(float dt) override;
     void Render() override;
     void GetBoundingBox(float &left, float &bottom, float &right, float &top) override;
+    
+    void SetState(int s);
+    void OnCollisionX(CGameObject* other, float nx) override;
+    void OnCollisionY(CGameObject* other, float ny) override;
+    bool IsBlocking(CGameObject* other) override;
+    int GetState() { return state; }
 };

--- a/game/entities/items/CCoin.cpp
+++ b/game/entities/items/CCoin.cpp
@@ -1,5 +1,7 @@
 #include "CCoin.h"
 #include "../../../engine/Graphics/Animations.h"
+#include "../../entities/player/CMario.h"
+#include "../../scenes/play/CPlayScene.h"
 
 CCoin::CCoin(float x, float y, bool hidden_in_block) : CGameObject() {
     this->x = x;
@@ -25,6 +27,10 @@ void CCoin::Update(float dt) {
             y = start_y;
             vy = 0;
             SetState(COIN_STATE_DONE); // Disappear after popping
+            if (scene) {
+                scene->AddCoin();
+                scene->AddScore(200);
+            }
         }
     }
 }
@@ -54,5 +60,27 @@ void CCoin::SetState(int s) {
     state = s;
     if (state == COIN_STATE_POPPING && in_block) {
         vy = COIN_POP_SPEED;
+    }
+}
+
+void CCoin::OnCollisionX(CGameObject* other, float nx) {
+    if (state == COIN_STATE_DONE || state == COIN_STATE_HIDDEN || in_block) return;
+    if (dynamic_cast<CMario*>(other)) {
+        SetState(COIN_STATE_DONE);
+        if (scene) {
+            scene->AddCoin();
+            scene->AddScore(200);
+        }
+    }
+}
+
+void CCoin::OnCollisionY(CGameObject* other, float ny) {
+    if (state == COIN_STATE_DONE || state == COIN_STATE_HIDDEN || in_block) return;
+    if (dynamic_cast<CMario*>(other)) {
+         SetState(COIN_STATE_DONE);
+         if (scene) {
+             scene->AddCoin();
+             scene->AddScore(200);
+         }
     }
 }

--- a/game/entities/items/CCoin.h
+++ b/game/entities/items/CCoin.h
@@ -18,4 +18,8 @@ public:
     void Render() override;
     void GetBoundingBox(float& left, float& bottom, float& right, float& top) override;
     void SetState(int s);
+
+    bool IsBlocking(CGameObject* other) override { return false; }
+    void OnCollisionX(CGameObject* other, float nx) override;
+    void OnCollisionY(CGameObject* other, float ny) override;
 };

--- a/game/entities/items/CMushroom.cpp
+++ b/game/entities/items/CMushroom.cpp
@@ -1,5 +1,7 @@
 #include "CMushroom.h"
 #include "../../../engine/Graphics/Animations.h"
+#include "../../entities/player/CMario.h"
+#include "../../scenes/play/CPlayScene.h"
 
 CMushroom::CMushroom(float x, float y) : CGameObject() {
     this->x = x;
@@ -37,4 +39,22 @@ void CMushroom::GetBoundingBox(float& left, float& bottom, float& right, float& 
 
 void CMushroom::SetState(int s) {
     state = s;
+}
+
+void CMushroom::OnCollisionX(CGameObject* other, float nx) {
+    if (state == MUSHROOM_STATE_HIDDEN) return;
+    if (auto mario = dynamic_cast<CMario*>(other)) {
+         SetState(MUSHROOM_STATE_HIDDEN); // Mark as consumed
+         if (scene) scene->AddScore(1000);
+         // Todo: make Mario become big mario
+    }
+}
+
+void CMushroom::OnCollisionY(CGameObject* other, float ny) {
+    if (state == MUSHROOM_STATE_HIDDEN) return;
+    if (auto mario = dynamic_cast<CMario*>(other)) {
+         SetState(MUSHROOM_STATE_HIDDEN); // Mark as consumed
+         if (scene) scene->AddScore(1000);
+         // Todo: make Mario become big mario
+    }
 }

--- a/game/entities/items/CMushroom.h
+++ b/game/entities/items/CMushroom.h
@@ -18,4 +18,8 @@ public:
     void Render() override;
     void GetBoundingBox(float& left, float& bottom, float& right, float& top) override;
     void SetState(int s);
+
+    bool IsBlocking(CGameObject* other) override { return (dynamic_cast<CMushroom*>(other) == nullptr); }
+    void OnCollisionX(CGameObject* other, float nx) override;
+    void OnCollisionY(CGameObject* other, float ny) override;
 };

--- a/game/scenes/play/CPlayScene.cpp
+++ b/game/scenes/play/CPlayScene.cpp
@@ -1,4 +1,5 @@
 #include "CPlayScene.h"
+#include <algorithm>
 #include "../../../engine/core/Game.h"
 #include "../../../engine/input/KeyboardManager.h"
 #include "../../../engine/physics/CCollision.h"
@@ -61,8 +62,50 @@ void CPlayScene::Update(float dt) {
 
   // Xử lý collision cho từng enemy với block xung quanh nó
   for (auto e : enemies) {
+    float old_vx = e->vx;
+
     auto blocksAroundEnemy = GetObjectsInRange(e->x, e->y, blocks);
-    CCollision::ResolveCollision(e, dt, blocksAroundEnemy);
+    auto enemiesAroundEnemy = GetObjectsInRange(e->x, e->y, enemies);
+
+    auto it = std::find(enemiesAroundEnemy.begin(), enemiesAroundEnemy.end(), e);
+    if (it != enemiesAroundEnemy.end()) enemiesAroundEnemy.erase(it);
+
+    std::vector<CGameObject*> coObjectsForEnemy = blocksAroundEnemy;
+    coObjectsForEnemy.insert(coObjectsForEnemy.end(), enemiesAroundEnemy.begin(), enemiesAroundEnemy.end());
+
+    CCollision::ResolveCollision(e, dt, coObjectsForEnemy);
+
+    if (e->vx == 0 && old_vx != 0) {
+      e->vx = -old_vx;
+      e->nx = (e->vx > 0) ? 1 : -1;
+    }
+
+    if (e->vy == 0 && e->vx != 0) {
+      float L, B, R, T;
+      e->GetBoundingBox(L, B, R, T);
+
+      CCollision::Box sensor;
+      if (e->vx < 0) {
+        sensor = CCollision::ToBox(L, B - 4.0f, L + 2.0f, B - 0.5f);
+      } else {
+        sensor = CCollision::ToBox(R - 2.0f, B - 4.0f, R, B - 0.5f);
+      }
+
+      bool hasFloor = false;
+      for (auto b : blocksAroundEnemy) {
+        float bl, bb, br, bt;
+        b->GetBoundingBox(bl, bb, br, bt);
+        if (CCollision::CheckAABB(sensor, CCollision::ToBox(bl, bb, br, bt))) {
+          hasFloor = true;
+          break;
+        }
+      }
+
+      if (!hasFloor) {
+        e->vx = -e->vx;
+        e->nx = (e->vx > 0) ? 1 : -1;
+      }
+    }
   }
 
   // Xử lý collision cho từng item với block xung quanh nó

--- a/game/scenes/play/CPlayScene.cpp
+++ b/game/scenes/play/CPlayScene.cpp
@@ -32,6 +32,11 @@ void CPlayScene::Load(const std::string &mapPath) {
 }
 
 void CPlayScene::Update(float dt) {
+  if (timeLeft > 0) {
+    timeLeft -= (dt / 1000.0f);
+    if (timeLeft < 0) timeLeft = 0;
+  }
+
   mario->Update(dt);
   for (auto b : blocks)
     b->Update(dt);

--- a/game/scenes/play/CPlayScene.h
+++ b/game/scenes/play/CPlayScene.h
@@ -18,6 +18,11 @@ class CPlayScene : public CScene {
   std::string currentMapPath;
   std::string pendingMapPath;
 
+  // HUD stats
+  int score = 0;
+  int coins = 0;
+  float timeLeft = 400.0f;
+
 public:
   void Load() override {
     Load("content/levels/level_1_1.csv");  // TODO: Remove hardcoded path
@@ -26,6 +31,12 @@ public:
   void Update(float dt) override;
   void Render() override;
   void Unload() override;
+
+  int GetScore() const { return score; }
+  void AddScore(int s) { score += s; }
+  int GetCoins() const { return coins; }
+  void AddCoin() { coins++; }
+  int GetTime() const { return (int)std::ceil(timeLeft); }
 
   void TransitionToMap(const std::string &mapPath) { pendingMapPath = mapPath; }
   void SetClearColor(D3DXCOLOR color) { clearColor = color; }
@@ -41,3 +52,5 @@ public:
     return result;
   }
 };
+
+extern CPlayScene* scene;


### PR DESCRIPTION
## Mô tả thay đổi
- **Smart Enemy Patrol & Wall Rebound (Task #50):**
  - Cập nhật logic di chuyển cho `CGoomba` và `CKoopa`. Lưu lại `old_vx` trước khi xử lý collision và chủ động đảo chiều `vx = -old_vx` khi va chạm với Box/Blocks hoặc Enemy khác.
  - Thêm logic quét cảm biến (sensor box) phía dướt mép tiến tới của kẻ địch. Tự động quay đầu nếu nhận diện phía trước là vực thẳm (không có vật thể chịu lực), tránh hiện tượng rơi hoặc đi lơ lửng ngoài mép.

- **Koopa Shell & Kick Mechanics (Task #51):**
  - Thiết lập State Machine cho `CKoopa` gồm 3 trạng thái: `WALKING`, `SHELL`, `SHELL_RUNNING`.
  - Mở rộng Engine Physics (`CCollision`) thông qua các phương thức `OnCollisionX`, `OnCollisionY` và `IsBlocking`.
  - Khi Mario dẫm lên (`OnCollisionY`): Koopa rụt vào mai, dừng di chuyển.
  - Khi Mario đá ngang (`OnCollisionX`): Mai rùa trượt đi với tốc độ cao. Nếu va chạm với kẻ địch khác (như Goomba), nó sẽ lập tức tiêu diệt kẻ địch và cộng điểm.

- **HUD (Heads-Up Display) Integration (Task #54):**
  - Khởi tạo Font Render `ID3DX10Font` trong `CGame` và hàm `DrawTextRaw` vẽ text trên Screen Space.
  - Render HUD trực tiếp trên Back Buffer trong `GameLoop.cpp` sau khi `spriteHandler->End()` để không bị trôi theo Camera.
  - Tích hợp số liệu Real-time (Score, Coins, Time đếm ngược, World Name) từ `CPlayScene`.
  - Bổ sung logic nối điểm, xu từ `CCoin`, `CMushroom`, `CGoomba`, `CKoopa` lên luồng dữ liệu HUD.

## Issue liên quan
- Closes #50
- Closes #51
- Closes #54

## Hình ảnh minh họa (nếu có)
<img width="148" height="63" alt="image" src="https://github.com/user-attachments/assets/9edc79a3-6d88-42bf-b1d6-99ca664d59de" />
<img width="143" height="71" alt="image" src="https://github.com/user-attachments/assets/cf0ccb68-b6ae-4f03-a478-60152d39a2ce" />
<img width="68" height="185" alt="image" src="https://github.com/user-attachments/assets/a3f5ba91-4323-423c-890c-ea3cafb4f621" />